### PR TITLE
WorldGuard Addon: Adding extended pattern setting with regex support

### DIFF
--- a/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/ColorRule.java
+++ b/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/ColorRule.java
@@ -4,42 +4,20 @@ import java.util.regex.Pattern;
 
 public class ColorRule {
     
-    final boolean usePattern;
-    
-    final String regionName;
-    final Pattern pattern;
-    
-    final RegionColors color;
-    
-    public ColorRule( String regionName, RegionColors color ) {
-        this.usePattern = false;
-        this.regionName = regionName;
-        this.pattern = null;
-        this.color = color;
-    }
+    private final Pattern pattern;
+    private final RegionColors color;
     
     public ColorRule( Pattern pattern, RegionColors color ) {
-        this.usePattern = true;
-        this.regionName = null;
         this.pattern = pattern;
         this.color = color;
     }
-    
+
     public RegionColors getColor() {
         return color;
     }
 
     public boolean isMatch( String targetRegionName ) {
-        if ( usePattern ) {
-            if ( pattern.matcher( targetRegionName ).matches() ) {
-                return true;
-            }
-        } else {
-            if ( regionName.equalsIgnoreCase( targetRegionName ) ) {
-                return true;
-            }
-        }
-        
-        return false;
+        // Note: "^" and "$" is not necessary in the regex pattern, because of the ".matcher()" check
+        return pattern.matcher( targetRegionName ).matches();
     }
 }

--- a/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/ColorRule.java
+++ b/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/ColorRule.java
@@ -1,0 +1,45 @@
+package io.github.bananapuncher714.cartographer.module.worldguard;
+
+import java.util.regex.Pattern;
+
+public class ColorRule {
+    
+    final boolean usePattern;
+    
+    final String regionName;
+    final Pattern pattern;
+    
+    final RegionColors color;
+    
+    public ColorRule( String regionName, RegionColors color ) {
+        this.usePattern = false;
+        this.regionName = regionName;
+        this.pattern = null;
+        this.color = color;
+    }
+    
+    public ColorRule( Pattern pattern, RegionColors color ) {
+        this.usePattern = true;
+        this.regionName = null;
+        this.pattern = pattern;
+        this.color = color;
+    }
+    
+    public RegionColors getColor() {
+        return color;
+    }
+
+    public boolean isMatch( String targetRegionName ) {
+        if ( usePattern ) {
+            if ( pattern.matcher( targetRegionName ).matches() ) {
+                return true;
+            }
+        } else {
+            if ( regionName.equalsIgnoreCase( targetRegionName ) ) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+}

--- a/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/WorldGuardModule.java
+++ b/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/WorldGuardModule.java
@@ -24,7 +24,7 @@ public class WorldGuardModule extends Module implements Listener {
 	public static final SettingStateBoolean WORLDGUARD_REGIONS = SettingStateBoolean.of( "worldguard_show_regions", false, true );
 	
 	protected Map< String, RegionColors > colors;
-	protected RegionColors defColors;
+	protected RegionColors defaultColors;
 	
 	protected WorldGuardWrapper wrapper;
 	
@@ -94,7 +94,7 @@ public class WorldGuardModule extends Module implements Listener {
 		if ( section == null ) {
 			getLogger().warning( "No 'colors' section found!" );
 		} else {
-			defColors = loadFrom( section.getConfigurationSection( "default" ) );
+			defaultColors = loadFrom( section.getConfigurationSection( "default" ) );
 			
 			if ( section.contains( "regions" ) ) {
 				ConfigurationSection regions = section.getConfigurationSection( "regions" );
@@ -113,7 +113,7 @@ public class WorldGuardModule extends Module implements Listener {
 	}
 	
 	protected RegionColors getFor( String name ) {
-		return colors.getOrDefault( name, defColors );
+		return colors.getOrDefault( name, defaultColors);
 	}
 	
 	protected WorldGuardWrapper getWrapper() {

--- a/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/WorldGuardModule.java
+++ b/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/WorldGuardModule.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -99,31 +100,22 @@ public class WorldGuardModule extends Module implements Listener {
 			defaultColors = loadFrom( section.getConfigurationSection( "default" ) );
 			
 			if ( section.contains( "regions" ) ) {
-				ConfigurationSection regionSection = section.getConfigurationSection( "regions" );
 				
-				for ( String key : regionSection.getKeys( false ) ) {
-					
-					ConfigurationSection region = regionSection.getConfigurationSection( key );
+				List< Map<?, ?> > regions = section.getMapList( "regions" );
 				
-					if ( region == null ) {
-						continue;
-					}
+				for ( Map<?, ?> map : regions ) {
+					String pattern = ( String ) map.get( "pattern" );
 					
-					// If the "pattern" setting is defined, use this value for extended pattern definition.
-					if ( region.contains( "pattern" ) ) {
-						try {
-							String regex = "^" + region.getString( "pattern" ) + "$";
-							colorRules.add( new ColorRule( Pattern.compile( regex ), loadFrom( regionSection.getConfigurationSection( key ) ) ) );
-						} catch ( PatternSyntaxException ex ) {
-							getLogger().warning( "Invalid region regex '" + key + "': " + ex.getMessage() );
-						}
-						
-					} else {
-						// Alternative: Use the config key for region name comparison.
-						colorRules.add( new ColorRule( key, loadFrom( regionSection.getConfigurationSection( key ) ) ) );
+					try {
+						colorRules.add( new ColorRule(
+								Pattern.compile( pattern ), 
+								loadFrom( map )
+						));
+					} catch ( PatternSyntaxException ex ) {
+						getLogger().warning( "Invalid regex '" + pattern + "': " + ex.getMessage() );
 					}
-					
 				}
+			
 			}
 		}
 	}
@@ -135,14 +127,17 @@ public class WorldGuardModule extends Module implements Listener {
 		return new RegionColors( owner, member, nonmember );
 	}
 	
+	private RegionColors loadFrom( Map<?, ?> map ) {
+		Color nonmember = PaletteManager.fromString( ( String ) map.get( "nonmember" ) ).get();
+		Color member = PaletteManager.fromString( ( String ) map.get( "member" ) ).get();
+		Color owner = PaletteManager.fromString( ( String ) map.get( "owner" ) ).get();
+		return new RegionColors( owner, member, nonmember );
+	}
+	
 	RegionColors getFor( String targetRegionName ) {
-		// Go through the configuration entries from bottom to top:
-		for ( int i = colorRules.size() - 1; i >= 0; i-- ) {
-			
-			ColorRule rule = colorRules.get( i );
-			
-			if ( rule.isMatch( targetRegionName ) ) {
-				return rule.getColor();
+		for ( ColorRule colorRule : colorRules ) {
+			if ( colorRule.isMatch( targetRegionName ) ) {
+				return colorRule.getColor();
 			}
 		}
 		return defaultColors;

--- a/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/WorldGuardModule.java
+++ b/addon/worldguard/module/src/main/java/io/github/bananapuncher714/cartographer/module/worldguard/WorldGuardModule.java
@@ -2,8 +2,10 @@ package io.github.bananapuncher714.cartographer.module.worldguard;
 
 import java.awt.Color;
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -23,7 +25,7 @@ import io.github.bananapuncher714.cartographer.module.worldguard.api.WorldGuardW
 public class WorldGuardModule extends Module implements Listener {
 	public static final SettingStateBoolean WORLDGUARD_REGIONS = SettingStateBoolean.of( "worldguard_show_regions", false, true );
 	
-	protected Map< String, RegionColors > colors;
+	protected List< ColorRule > colorRules;
 	protected RegionColors defaultColors;
 	
 	protected WorldGuardWrapper wrapper;
@@ -43,7 +45,7 @@ public class WorldGuardModule extends Module implements Listener {
 			return;
 		}
 		
-		colors = new HashMap< String, RegionColors >();
+		colorRules = new ArrayList<>();
 		loadConfig();
 
 		for ( Minimap minimap : getCartographer().getMapManager().getMinimaps().values() ) {
@@ -86,7 +88,7 @@ public class WorldGuardModule extends Module implements Listener {
 	}
 	
 	private void loadConfig() {
-		colors.clear();
+		colorRules.clear();
 		
 		FileConfiguration config = YamlConfiguration.loadConfiguration( new File( getDataFolder(), "config.yml" ) );
 		ConfigurationSection section = config.getConfigurationSection( "colors" );
@@ -97,9 +99,30 @@ public class WorldGuardModule extends Module implements Listener {
 			defaultColors = loadFrom( section.getConfigurationSection( "default" ) );
 			
 			if ( section.contains( "regions" ) ) {
-				ConfigurationSection regions = section.getConfigurationSection( "regions" );
-				for ( String key : regions.getKeys( false ) ) {
-					colors.put( key, loadFrom( regions.getConfigurationSection( key ) ) );
+				ConfigurationSection regionSection = section.getConfigurationSection( "regions" );
+				
+				for ( String key : regionSection.getKeys( false ) ) {
+					
+					ConfigurationSection region = regionSection.getConfigurationSection( key );
+				
+					if ( region == null ) {
+						continue;
+					}
+					
+					// If the "pattern" setting is defined, use this value for extended pattern definition.
+					if ( region.contains( "pattern" ) ) {
+						try {
+							String regex = "^" + region.getString( "pattern" ) + "$";
+							colorRules.add( new ColorRule( Pattern.compile( regex ), loadFrom( regionSection.getConfigurationSection( key ) ) ) );
+						} catch ( PatternSyntaxException ex ) {
+							getLogger().warning( "Invalid region regex '" + key + "': " + ex.getMessage() );
+						}
+						
+					} else {
+						// Alternative: Use the config key for region name comparison.
+						colorRules.add( new ColorRule( key, loadFrom( regionSection.getConfigurationSection( key ) ) ) );
+					}
+					
 				}
 			}
 		}
@@ -112,8 +135,17 @@ public class WorldGuardModule extends Module implements Listener {
 		return new RegionColors( owner, member, nonmember );
 	}
 	
-	protected RegionColors getFor( String name ) {
-		return colors.getOrDefault( name, defaultColors);
+	RegionColors getFor( String targetRegionName ) {
+		// Go through the configuration entries from bottom to top:
+		for ( int i = colorRules.size() - 1; i >= 0; i-- ) {
+			
+			ColorRule rule = colorRules.get( i );
+			
+			if ( rule.isMatch( targetRegionName ) ) {
+				return rule.getColor();
+			}
+		}
+		return defaultColors;
 	}
 	
 	protected WorldGuardWrapper getWrapper() {

--- a/addon/worldguard/module/src/main/resources/config.yml
+++ b/addon/worldguard/module/src/main/resources/config.yml
@@ -2,11 +2,21 @@
 
 # The various colors for each region
 colors:
-  # Custom color scheme for certain regions, like spawn
+  # Custom color scheme for certain regions, like "spawn"
+  # The region settings are checked from bottom to top until the first match is found.
+  #
+  # Use the optional "pattern" setting for expanded region name pattern definition.
+  # This option supports regex (https://regexr.com), like "shop-[1-3]" or ".*_admin".
+  # Without this setting, the YAML config key is used for normal region name definition (without regex support).
   regions:
     spawn:
       nonmember: "0x408800"
       member: "0x408800"
+      owner: "#00FF00"
+    admin-shops:
+      pattern: "shop-[1-3]"
+      nonmember: "#FF0000"
+      member: "#00698c"
       owner: "#00FF00"
   # The default color scheme for regions that aren't specified in the region section
   # It supports RGB, hex or an integer

--- a/addon/worldguard/module/src/main/resources/config.yml
+++ b/addon/worldguard/module/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-## World Guard Module for Cartographer 2
+## WorldGuard Module for Cartographer 2
 
 # The various colors for each region
 colors:
@@ -11,7 +11,7 @@ colors:
   # The default color scheme for regions that aren't specified in the region section
   # It supports RGB, hex or an integer
   default:
-    # The color that non members view regions as
+    # The color that non-members view regions as
     nonmember: "#FFFF00"
     # The color that members view the region as
     member: "#00FFFF"

--- a/addon/worldguard/module/src/main/resources/config.yml
+++ b/addon/worldguard/module/src/main/resources/config.yml
@@ -3,21 +3,17 @@
 # The various colors for each region
 colors:
   # Custom color scheme for certain regions, like "spawn"
-  # The region settings are checked from bottom to top until the first match is found.
-  #
-  # Use the optional "pattern" setting for expanded region name pattern definition.
-  # This option supports regex (https://regexr.com), like "shop-[1-3]" or ".*_admin".
-  # Without this setting, the YAML config key is used for normal region name definition (without regex support).
+  # The region settings are checked from top to bottom until the first match is found.
+  # The region name pattern supports regex (https://regexr.com), like "shop-[1-3]" or ".*_admin".
   regions:
-    spawn:
-      nonmember: "0x408800"
-      member: "0x408800"
-      owner: "#00FF00"
-    admin-shops:
-      pattern: "shop-[1-3]"
-      nonmember: "#FF0000"
-      member: "#00698c"
-      owner: "#00FF00"
+  - pattern: "spawn"
+    nonmember: "0x408800"
+    member: "0x408800"
+    owner: "#00FF00"
+  - pattern: "shop-[1-3]"
+    nonmember: "#FF0000"
+    member: "#00698c"
+    owner: "#00FF00"
   # The default color scheme for regions that aren't specified in the region section
   # It supports RGB, hex or an integer
   default:


### PR DESCRIPTION
# Overview

Fixing #41

- Adding extended pattern setting
  - Adding `ColorRule` object
  - Replacing region-to-color HashMap with `ColorRule` object list
  - Updating config and adding description comments
  - Reworking config reader
  - Reworking region check to get the final color
- Improving spelling (small)

# Concept

**YAML key vs. new pattern setting:**
To ensure that existing configurations continue to function as intended, the YAML key for the “normal” simple region name check was left unchanged. Only if the admin wants more precision, they can use the new “pattern” setting to define a region name pattern that also allows regular expressions. This is also explained in the comments within the configuration file.

This also resolves issues with the YAML syntax: `.` or other characters are interpreted differently by YAML / YAML parsing methods, which would otherwise occasionally lead to pattern limitations and configuration mistakes by the admin.

**Order of priority:**
The definitions (region name or pattern) in the config are checked in the object list from _bottom to top_ to allow a natural order: the general definitions are at the top, and the further down the list the definition appears, the more specific it is.

# Tests

The config was tested in PaperMC 1.21.1, with Cartographer2 version `2.15.17`.

<img width="600" height="358" alt="Screenshot 2026-07-16 015245" src="https://github.com/user-attachments/assets/cc6f2267-5748-4f08-9c43-87c94e659709" />

<details>
<summary>Expand to see the test-config</summary>

```yaml
## WorldGuard Module for Cartographer 2

# The various colors for each region
colors:
  # Custom color scheme for certain regions, like "spawn"
  # The region settings are checked from bottom to top until the first match is found.
  #
  # Use the optional "pattern" setting for expanded region name pattern definition.
  # This option supports regex (https://regexr.com), like "shop-[1-3]" or ".*_admin".
  # Without this setting, the YAML config key is used for normal region name definition (without regex support).
  regions:
#    spawn:
#      nonmember: "0x408800"
#      member: "0x408800"
#      owner: "#00FF00"
#    admin-shops:
#      pattern: "shop-[1-3]"
#      nonmember: "#FF0000"
#      member: "#00698c"
#      owner: "#00FF00"
    test1:
      pattern: "wg-.*"
      nonmember: "#b38600"
      member: "#535362"
      owner: "#ff2626"
    test2:
      pattern: "wg-sections_.*"
      nonmember: "#265cff"
      member: "#26ff26"
      owner: "#00008c"
    test3:
      pattern: "wg-sections_a[1-8]"
      nonmember: "#0f0f1e"
      member: "#535362"
      owner: "#00698c"
    test4:
      pattern: ".*_c[1-3]"
      nonmember: "#ff00ff"
      member: "#008c00"
      owner: "#d2ff4c"
    wg-sections_a1:
      nonmember: "#0f0f1e"
      member: "#794cff"
      owner: "#d90036"
  # The default color scheme for regions that aren't specified in the region section
  # It supports RGB, hex or an integer
  default:
    # The color that non-members view regions as
    nonmember: "#FFFF00"
    # The color that members view the region as
    member: "#00FFFF"
    # The color that owners view the region as
    owner: "#00FF00"
```

</details>